### PR TITLE
fix: use .asc extension for ASCII-armored antigravity key

### DIFF
--- a/roles/rotarymars_setup/vars/main/apt.yml
+++ b/roles/rotarymars_setup/vars/main/apt.yml
@@ -15,7 +15,7 @@ apt_keys:
   - url: https://www.virtualbox.org/download/oracle_vbox_2016.asc
     keyname: /usr/share/keyrings/oracle-vbox.asc
   - url: https://us-central1-apt.pkg.dev/doc/repo-signing-key.gpg
-    keyname: /etc/apt/keyrings/antigravity-repo-key.gpg
+    keyname: /etc/apt/keyrings/antigravity-repo-key.asc
 apt_repositories:
   - deb [arch=amd64 signed-by=/etc/apt/keyrings/googlechrom-keyring.asc] http://dl.google.com/linux/chrome/deb/ stable main
   - ppa:kicad/kicad-9.0-releases
@@ -28,7 +28,7 @@ apt_repositories:
   - ppa:lakinduakash/lwh
   - deb [arch=amd64 signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main
   - deb [signed-by=/usr/share/keyrings/oracle-vbox.asc] https://download.virtualbox.org/virtualbox/debian {{ ansible_distribution_release }}  contrib
-  - deb [signed-by=/etc/apt/keyrings/antigravity-repo-key.gpg] https://us-central1-apt.pkg.dev/projects/antigravity-auto-updater-dev/ antigravity-debian main
+  - deb [signed-by=/etc/apt/keyrings/antigravity-repo-key.asc] https://us-central1-apt.pkg.dev/projects/antigravity-auto-updater-dev/ antigravity-debian main
 apt_packages:
   - dirmngr
   - ca-certificates


### PR DESCRIPTION
## Summary
- The Google Artifact Registry signing key at `https://us-central1-apt.pkg.dev/doc/repo-signing-key.gpg` is ASCII-armored, but was being saved to `/etc/apt/keyrings/antigravity-repo-key.gpg`. apt treats `.gpg` as binary and `.asc` as ASCII-armored, so it couldn't read the key, failed to verify the repo's `InRelease` (`NO_PUBKEY C0BA5CE6DC6315A3`), and broke CI.
- Renamed the keyname to `.asc` (matching actual content) and updated the `signed-by=` reference in the repo line.

## Test plan
- [ ] CI (`Test Ansible Playbook`) goes green on this PR
- [ ] `apt update` on a fresh Ubuntu Noble install no longer warns about the antigravity repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)