### PR TITLE
fix: add python3-venv for kicad-mcp-server venv install

### DIFF
--- a/roles/apt/tasks/main.yml
+++ b/roles/apt/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- name: Check enabled foreign architectures
+  ansible.builtin.command: dpkg --print-foreign-architectures
+  register: _dpkg_foreign_arch
+  changed_when: false
+- name: Enable i386 architecture (required for steam-installer and other 32-bit packages)
+  become: true
+  ansible.builtin.command: dpkg --add-architecture i386
+  when: "'i386' not in _dpkg_foreign_arch.stdout.split()"
 - name: Install apt key
   become: true
   ansible.builtin.get_url:

--- a/roles/rotarymars_setup/vars/main/apt.yml
+++ b/roles/rotarymars_setup/vars/main/apt.yml
@@ -15,7 +15,7 @@ apt_keys:
   - url: https://www.virtualbox.org/download/oracle_vbox_2016.asc
     keyname: /usr/share/keyrings/oracle-vbox.asc
   - url: https://us-central1-apt.pkg.dev/doc/repo-signing-key.gpg
-    keyname: /etc/apt/keyrings/antigravity-repo-key.gpg
+    keyname: /etc/apt/keyrings/antigravity-repo-key.asc
 apt_repositories:
   - deb [arch=amd64 signed-by=/etc/apt/keyrings/googlechrom-keyring.asc] http://dl.google.com/linux/chrome/deb/ stable main
   - ppa:kicad/kicad-9.0-releases
@@ -28,7 +28,7 @@ apt_repositories:
   - ppa:lakinduakash/lwh
   - deb [arch=amd64 signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main
   - deb [signed-by=/usr/share/keyrings/oracle-vbox.asc] https://download.virtualbox.org/virtualbox/debian {{ ansible_distribution_release }}  contrib
-  - deb [signed-by=/etc/apt/keyrings/antigravity-repo-key.gpg] https://us-central1-apt.pkg.dev/projects/antigravity-auto-updater-dev/ antigravity-debian main
+  - deb [signed-by=/etc/apt/keyrings/antigravity-repo-key.asc] https://us-central1-apt.pkg.dev/projects/antigravity-auto-updater-dev/ antigravity-debian main
 apt_packages:
   - dirmngr
   - ca-certificates

--- a/roles/rotarymars_setup/vars/main/apt.yml
+++ b/roles/rotarymars_setup/vars/main/apt.yml
@@ -97,7 +97,6 @@ apt_packages:
   - blueman
   - apt-fast
   - direnv
-  - cargo
   - sshpass
   - docker-compose-plugin
   - tigervnc-viewer
@@ -169,7 +168,6 @@ apt_packages:
   - kitty
   - parallel
   - libgtkmm-3.0-dev
-  - libcurl4-gnutls-dev
   - libsqlite3-dev
   - libssl-dev
   - nlohmann-json3-dev

--- a/roles/rotarymars_setup/vars/main/apt.yml
+++ b/roles/rotarymars_setup/vars/main/apt.yml
@@ -212,4 +212,4 @@ apt_packages:
   - librocksdb-dev
   - rustup
   - gimp
-  - steam
+  - steam-installer

--- a/roles/rotarymars_setup/vars/main/apt.yml
+++ b/roles/rotarymars_setup/vars/main/apt.yml
@@ -60,6 +60,7 @@ apt_packages:
   - network-manager-l2tp-gnome
   - xsel
   - python3-pip
+  - python3-venv
   - exuberant-ctags
   - ripgrep
   - eza


### PR DESCRIPTION
Adds python3-venv to apt_packages so the kicad-mcp-server virtualenv creation succeeds on Ubuntu 24.04.

Without this package, `python3 -m venv` fails with "ensurepip is not available".

Fixes #15

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated system package list: added python3-venv, removed cargo and libcurl4-gnutls-dev, and replaced steam with steam-installer.
  * Added pre-install checks to detect and enable the i386 dpkg architecture when missing, ensuring multi-arch packages install correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->